### PR TITLE
Update circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,11 @@ workflows:
       - ensure_version_bump:
           requires:
             - build
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
       - publish:
           requires:
             - ensure_version_bump
-          filters:
-            branches:
-              only: master


### PR DESCRIPTION
Only run the ensure_version_bump job on tagged releases and exclude all branches