### PR TITLE
Polymorph Function

### DIFF
--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-import styled from "lib/styled";
 import {
   backgroundSet,
   BackgroundSetProps,
@@ -20,6 +18,9 @@ import {
   propTypes,
 } from "onno-react";
 
+import styled from "lib/styled";
+import { polymorph } from "lib/polymorph";
+
 export type BoxProps = BackgroundSetProps &
   BorderSetProps &
   SpaceSetProps &
@@ -29,7 +30,7 @@ export type BoxProps = BackgroundSetProps &
   LayoutSetProps &
   TransformSetProps;
 
-const Box: React.FC<BoxProps> = styled.div<BoxProps>(
+const Box = styled(polymorph<BoxProps>("div"))(
   backgroundSet,
   borderSet,
   displaySet,

--- a/src/lib/polymorph.tsx
+++ b/src/lib/polymorph.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { omit } from "onno-react";
+
+export interface PolymorphProps {
+  as?: React.ElementType;
+}
+
+const omitPolymorphProps = omit({ propsKeys: ["as"] });
+
+export function polymorph<P extends unknown>(
+  defaultEl: React.ElementType,
+): React.FunctionComponent<PolymorphProps & P> {
+  return props => {
+    const Element = props.as || defaultEl;
+    return <Element {...omitPolymorphProps(props)} />;
+  };
+}


### PR DESCRIPTION
This new polymorph function can be used to turn components into polymorphic elements, meaning using the `as` prop to transform the underlying html element. This is useful and will give us the
flexibility to achieve max semantic html. The big advantage of using this function is that we can
stop manually adding the `as` prop and having to deal with it in every new interface we roll. the
downside is that it will require quite a change in the api, but this isnt that big of a tradeoff
becuase we are in the middle of a big refactor to work with onno.