### PR TITLE
Swap size prop for fontSize in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import { ThemeDecorator, Section, Text } from '@mojotech/mojo-ui'
 const Page: React.FunctionComponent = () => (
   <ThemeDecorator>
     <Section>
-      <Text as="h1" size={6}>Build Better.</Text>
+      <Text as="h1" fontSize={5}>Build Better.</Text>
     </Section>
   </ThemeDecorator>
 )


### PR DESCRIPTION
`size` prop is no longer used on `Text` component. Swapped it for the proper prop `fontSize`.