### PR TITLE
Rename darkgreen in theme to meangreen

### DIFF
--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,7 +1,7 @@
 export default {
   colors: {
     mojogreen: "#00ba40",
-    darkgreen: "#1E4D32",
+    meangreen: "#1E4D32",
     white: "#ffffff",
     dark: "#14111D",
     gray: "#F0F0F0",

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -2,7 +2,7 @@ export type Theme = {
   spaces: string[];
   colors: {
     mojogreen: string;
-    darkgreen: string;
+    meangreen: string;
     white: string;
     dark: string;
     gray: string;


### PR DESCRIPTION
darkgreen is already a css color name and is overwriting our version of darkgreen