### PR TITLE
Transfer default props TextLink to Text

### DIFF
--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -58,8 +58,10 @@ const Text: React.FC<Props> = styled(polymorph<Props>("p"))<Props>(
 );
 
 Text.defaultProps = {
+  color: "inherit",
   fontSize: 0,
   fontFamily: "main",
+  textDecoration: "none",
 };
 
 Text.displayName = "Text";

--- a/src/components/TextLink.tsx
+++ b/src/components/TextLink.tsx
@@ -51,10 +51,8 @@ const TextLink: React.FC<Props> = styled(Text)<Props>(props =>
 
 TextLink.defaultProps = {
   as: "a",
-  color: "inherit",
   cursor: "pointer",
   scheme: "light",
-  textDecoration: "none",
   underline: false,
   ...Text.defaultProps,
 };


### PR DESCRIPTION
Move textDecoration and inherit color from TextLink to Text in order to use Text
component as an anchor tag